### PR TITLE
Fix: Correct URL formation in Utility.ts for ping operations

### DIFF
--- a/nodes/Planaday/resources/Utility.ts
+++ b/nodes/Planaday/resources/Utility.ts
@@ -1,0 +1,44 @@
+import { IExecuteFunctions, INodeExecutionData, NodeOperationError } from 'n8n-workflow';
+
+/**
+ * Executes the ping operation to the Planaday API
+ */
+export async function executePing(this: IExecuteFunctions, itemIndex: number): Promise<INodeExecutionData[]> {
+	const returnData: INodeExecutionData[] = [];
+
+	try {
+		const responseData = await this.helpers.httpRequestWithAuthentication.call(
+			this,
+			'planadayApi', 
+			{
+				method: 'GET',
+				url: `/v1/ping`, // Ensure correct credential access
+				json: false, 
+			},
+		);
+
+		const result = typeof responseData === 'string' ? { message: responseData } : responseData;
+
+		// For a global operation like ping, we typically return one item of data.
+		// If this function is guaranteed to be called only once, itemIndex might be irrelevant for pairedItem.
+		returnData.push({
+			json: result,
+			// No pairedItem needed if it's a global action not tied to input items.
+		});
+
+	} catch (error) {
+		if (this.continueOnFail()) {
+			const errorData = { error: (error as Error).message };
+			// itemIndex is passed, use it if an error needs to be associated with an (even conceptual) item.
+			returnData.push({ json: errorData, pairedItem: { item: itemIndex } }); 
+			return returnData;
+		} else {
+			const nodeError = new NodeOperationError(this.getNode(), error as Error, {
+				description: `Ping operation failed: ${(error as Error).message}`,
+				itemIndex,
+			});
+			throw nodeError;
+		}
+	}
+	return returnData;
+}

--- a/nodes/Planaday/resources/index.ts
+++ b/nodes/Planaday/resources/index.ts
@@ -1,2 +1,3 @@
 export * from './Student';
 export * from './Base';
+export * from './Utility';


### PR DESCRIPTION
The original issue you reported was an 'Invalid URL' error during a ping operation in the Planaday custom n8n node. I traced this to the `executePing` function in `Utility.ts` (located in your n8n custom node directory) where the `url` for `httpRequestWithAuthentication` was specified as `={{$credentials.apiUrl}}/v1/ping`. This expression syntax is not evaluated in that context, leading to an invalid URL.

This commit introduces a new `Utility.ts` file into the repository's `nodes/Planaday/resources/` directory with the corrected URL formation. The `url` is now set to `/v1/ping`, allowing the `httpRequestWithAuthentication` helper to correctly prepend the `baseURL` (derived from `$credentials.apiUrl`) from the node's defaults.

The `nodes/Planaday/resources/index.ts` file has also been updated to export the contents of the new `Utility.ts`.

Note: To resolve the immediate error, you will need to apply the same fix manually to the `Utility.ts` file located in your n8n instance's custom node directory (`/home/node/.n8n/custom/node_modules/nodes/Planaday/resources/Utility.ts`).