### PR TITLE
fix: use relative URL for student creation

### DIFF
--- a/nodes/Planaday/resources/Student.ts
+++ b/nodes/Planaday/resources/Student.ts
@@ -365,7 +365,7 @@ export async function createStudent(
 			'planadayApi',
 			{
 				method: 'POST',
-				url: '={{$credentials.apiUrl}}/v1/student',
+                                url: '/v1/student',
 				body,
 				json: true,
 			},


### PR DESCRIPTION
## Summary
- use a relative URL when creating a student

## Testing
- `pnpm lint` *(fails: node-class-description errors)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6844bca545c88325a26af51d350e9405